### PR TITLE
Fix index errors in ripple and band calc

### DIFF
--- a/src/calculation/calc_band.cpp
+++ b/src/calculation/calc_band.cpp
@@ -20,7 +20,7 @@ double calc_band(vector<vector<double>> csv_array, double gain) {
     double freq_l = 0, freq_h = 0;
     double bandwidth = 0;
 
-    for (int i = 0; i < csv_array.size() - 1; i++) {
+    for (size_t i = 0; i + 1 < csv_array.size(); ++i) {
         if(csv_array[i][1] <= gain_half){
             if(csv_array[i + 1][1] >= gain_half){
                 freq_l = (csv_array[i][0] + csv_array[i + 1][0]) / 2;
@@ -29,10 +29,11 @@ double calc_band(vector<vector<double>> csv_array, double gain) {
         }
     }
 
-    for (int i = csv_array.size() - 1; i >= 0; i--) {
-        if(csv_array[i][1] <= gain_half){
-            if(csv_array[i - 1][1] >= gain_half){
-                freq_h = (csv_array[i][0] + csv_array[i - 1][0]) / 2;
+    for (size_t i = csv_array.size(); i > 1; --i) {
+        size_t idx = i - 1;
+        if(csv_array[idx][1] <= gain_half){
+            if(csv_array[idx - 1][1] >= gain_half){
+                freq_h = (csv_array[idx][0] + csv_array[idx - 1][0]) / 2;
                 break;
             }
         }

--- a/src/calculation/calc_ripple.cpp
+++ b/src/calculation/calc_ripple.cpp
@@ -21,12 +21,12 @@ double calc_ripple(vector<vector<double>> csv_array, double freq_r){
     double min = 0, max = 0;
     double judge_updown = 0; // -1なら減少、1なら上昇 (一つ前のサイクル)
 
-    for (int i = 0; i < csv_array.size(); i++) {
+    for (size_t i = 1; i < csv_array.size(); ++i) {
         if(csv_array[i][0] >= freq - WIDTH_F && csv_array[i][0] <= freq){  //範囲を共振周波数から0.5 GHz低いところから1.5GHzの幅の間のみを探索
             if(csv_array[i][1] >= csv_array[i - 1][1]){ //前サイクルよりも上昇していれば
                 if(judge_updown == -1){  //前サイクルが減少していれば (減少 → 上昇 なので負のピーク)
                     min = csv_array[i - 1][1];
-                    if(max - min >= ripple && max != 0){   //max - min の値が既存のrippleよりも大きければrippleの最大値を更新 
+                    if(max - min >= ripple && max != 0){   //max - min の値が既存のrippleよりも大きければrippleの最大値を更新
                         ripple = max - min;                //"max != 0" はmaxが初期値ではない場合であり、(正のピーク) - (負のピーク)を計算する関係上、先に正のピークを迎えてくれないと困るため
                     }
                 }


### PR DESCRIPTION
## Summary
- prevent negative indexing in `calc_ripple` and `calc_band`

## Testing
- `make` *(fails: pagmo/pagmo.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841c63710a483258b1388f18aa4ad95