### PR TITLE
Add BFE parallel nsga2 implementation

### DIFF
--- a/include/function.hpp
+++ b/include/function.hpp
@@ -34,14 +34,14 @@ void execute_julia(std::string jl_source);
 
 //file
 void read_jl(std::vector<ele_unit> &ele, std::vector<std::string> &jl_source);
-void write_jl(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source);
-std::vector<std::vector<double>> read_csv();
+void write_jl(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source, std::size_t tid = 0);
+std::vector<std::vector<double>> read_csv(std::size_t tid = 0);
 
 //display
 void display_element(const std::vector<ele_unit> &ele);
 
 //calculation
-result calculation(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source);
+result calculation(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source, std::size_t tid = 0);
 double calc_gain(std::vector<std::vector<double>> csv_array, double freq_r);
 double calc_band(std::vector<std::vector<double>> csv_array, double gain);
 double calc_ripple(std::vector<std::vector<double>> csv_array, double freq_r);
@@ -59,5 +59,6 @@ void run_nsga2(int pop_size,int generations, std::vector<ele_unit> ele, std::vec
 void run_nsga2_pagmo(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_pagmo_codex(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_pagmo_par(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
+void run_nsga2_pagmo_bfe(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 
 #endif

--- a/src/calculation/calculation.cpp
+++ b/src/calculation/calculation.cpp
@@ -16,17 +16,19 @@
 using namespace std;
 
 
-result calculation(const vector<ele_unit> &ele, const vector<string> &jl_source) {
+result calculation(const vector<ele_unit> &ele, const vector<string> &jl_source, std::size_t tid) {
     stringstream jl_name, liness;
-    jl_name << "TWPA_" << getpid() << ".jl";
+    jl_name << "TWPA_" << getpid();
+    if(tid != 0) jl_name << '_' << tid;
+    jl_name << ".jl";
 
-    write_jl(ele, jl_source);
+    write_jl(ele, jl_source, tid);
     result result;
     display_element(ele);
     cout << " exuecuting Julia ..." << endl;
     execute_julia(jl_name.str()); // julia を実行
 
-    vector<vector<double>> csv_array = read_csv();
+    vector<vector<double>> csv_array = read_csv(tid);
 
     result.gain = calc_gain(csv_array, calc_freq_r(ele));
     result.bandwidth = calc_band(csv_array, result.gain);

--- a/src/file/read_csv.cpp
+++ b/src/file/read_csv.cpp
@@ -17,13 +17,15 @@ using namespace std;
 
 
 /* Josimの結果を配列に格納 */
-vector<vector<double>> read_csv() {
+vector<vector<double>> read_csv(std::size_t tid) {
     double out;
     stringstream outfile, delete_csv;
     stringstream outline;
     string line;
     vector<vector<double>> csv_array;
-    outfile << "freq_gain_" << getpid() << ".csv";
+    outfile << "freq_gain_" << getpid();
+    if(tid != 0) outfile << '_' << tid;
+    outfile << ".csv";
     delete_csv << "rm -rf " << outfile.str();
     /* テキストファイルの読み込み */
     ifstream fp_csv(outfile.str());

--- a/src/file/write_jl.cpp
+++ b/src/file/write_jl.cpp
@@ -14,10 +14,14 @@
 
 using namespace std;
 
-void write_jl(const vector<ele_unit> &ele, const vector<string> &jl_source){ //for writing .jl file of new parameters
+void write_jl(const vector<ele_unit> &ele, const vector<string> &jl_source, std::size_t tid){ //for writing .jl file of new parameters
     stringstream jl_name, liness, csv_line;
-    jl_name << "TWPA_" << getpid() << ".jl";
-    csv_line << "    open(\"freq_gain_" <<  getpid() << ".csv\", \"w\") do io";
+    jl_name << "TWPA_" << getpid();
+    if(tid != 0) jl_name << '_' << tid;
+    jl_name << ".jl";
+    csv_line << "    open(\"freq_gain_" <<  getpid();
+    if(tid != 0) csv_line << '_' << tid;
+    csv_line << ".csv\", \"w\") do io";
     ofstream fpin(jl_name.str());
     int y = 0;
     vector<string> jl_source_copy = jl_source;

--- a/src/nsga2/nsga2_pagmo_bfe.cpp
+++ b/src/nsga2/nsga2_pagmo_bfe.cpp
@@ -1,0 +1,147 @@
+#include "function.hpp"
+#include <random>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <utility>
+#include <thread>
+#include <functional>
+
+#if __has_include(<pagmo/pagmo.hpp>)
+#include <pagmo/pagmo.hpp>
+#include <pagmo/algorithms/nsga2.hpp>
+#include <pagmo/population.hpp>
+#include <pagmo/types.hpp>
+#include <pagmo/batch_evaluators/thread_bfe.hpp>
+#define PAGMO_AVAILABLE 1
+#else
+#pragma message("pagmo library not found, run_nsga2_pagmo_bfe will be disabled")
+#define PAGMO_AVAILABLE 0
+#endif
+
+#if PAGMO_AVAILABLE
+using pagmo::vector_double;
+
+using pagmo::problem;
+using pagmo::algorithm;
+using pagmo::population;
+using pagmo::nsga2;
+
+
+//======================================
+// UDP: JosephsonCircuits を呼び出して (gain, bandwidth, ripple) を得る
+//======================================
+struct josephson_problem {
+    double Lj;
+    std::vector<ele_unit> ele;
+    std::vector<std::string> jl_source;
+    double Cg_min, Cg_max, Cc_min, Cc_max;
+
+    josephson_problem() = default;
+    josephson_problem(double Lj_, const std::vector<ele_unit>& ele_,
+                      const std::vector<std::string>& jl_src_)
+        : Lj(Lj_), ele(ele_), jl_source(jl_src_) {}
+
+    result eval(double Cg, double Cc) const {
+        auto tmp = ele;
+        change_param(tmp, "Cg", Cg);
+        change_param(tmp, "Cc", Cc);
+        double denom = 3.0 * Lj / (49.0 * 49.0);
+        double Cn = denom - 2.0 * Cg - Cc;
+        if (Cn <= 0.0) {
+            return {0.0, 0.0, 1.0};
+        }
+        change_param(tmp, "Cn", Cn);
+        auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        return calculation(tmp, jl_source, tid);
+    }
+
+    vector_double fitness(const vector_double &x) const {
+        result r = eval(x[0], x[1]);
+        double f1 = -r.gain;
+        double f2 = -r.bandwidth;
+        if (r.ripple > 0.1) {
+            f1 = 1e6 + r.ripple;
+            f2 = 1e6 + r.ripple;
+        }
+        return {f1, f2};
+    }
+
+    std::pair<vector_double, vector_double> get_bounds() const {
+        return {{Cg_min, Cc_min}, {Cg_max, Cc_max}};
+    }
+
+    std::size_t get_nobj() const { return 2u; }
+    std::size_t get_nic() const { return 0u; }
+    std::size_t get_nec() const { return 0u; }
+
+    void set_bounds(double _Cg_min, double _Cg_max,
+                    double _Cc_min, double _Cc_max) {
+        Cg_min = _Cg_min;  Cg_max = _Cg_max;
+        Cc_min = _Cc_min;  Cc_max = _Cc_max;
+    }
+
+    std::string get_name() const { return "josephson_problem"; }
+};
+
+//======================================
+// run_nsga2_pagmo_bfe ：Pagmo を使った NSGA‐II 実行 (Batch Fitness Evaluator 使用)
+//======================================
+void run_nsga2_pagmo_bfe(int pop_size,
+                     int generations,
+                     const std::vector<ele_unit>& ele,
+                     const std::vector<std::string>& jl_source,
+                     double Lj,
+                     double Cg_min, double Cg_max,
+                     double Cc_min, double Cc_max) {
+    josephson_problem prob_udp(Lj, ele, jl_source);
+    prob_udp.set_bounds(Cg_min, Cg_max, Cc_min, Cc_max);
+
+    pagmo::problem prob{prob_udp};
+
+    pagmo::algorithm algo{ pagmo::nsga2(
+        generations,
+        0.9,
+        20.0,
+        1.0/2.0,
+        20.0
+    ) };
+
+    pagmo::thread_bfe bfe{};
+
+    pagmo::population pop{prob, bfe, static_cast<unsigned int>(pop_size)};
+    pop = algo.evolve(pop);
+
+    std::cout << "# Cg\tCc\tCn\tgain\tbandwidth\tripple\n";
+    for (std::size_t i = 0; i < pop.size(); ++i) {
+        const auto xv = pop.get_x()[i];
+        double Cg = xv[0];
+        double Cc = xv[1];
+        result r = prob_udp.eval(Cg, Cc);
+        double denom = 3.0 * Lj / (49.0 * 49.0);
+        double Cn = denom - 2.0 * Cg - Cc;
+        if (r.ripple <= 0.1 && Cn > 0.0) {
+            std::cout << Cg << "\t"
+                      << Cc << "\t"
+                      << Cn << "\t"
+                      << r.gain << "\t"
+                      << r.bandwidth << "\t"
+                      << r.ripple << "\n";
+        }
+    }
+}
+#else
+void run_nsga2_pagmo_bfe(int pop_size,
+                     int generations,
+                     const std::vector<ele_unit>& ele,
+                     const std::vector<std::string>& jl_source,
+                     double Lj,
+                     double Cg_min, double Cg_max,
+                     double Cc_min, double Cc_max) {
+    (void)pop_size; (void)generations; (void)ele; (void)jl_source;
+    (void)Lj; (void)Cg_min; (void)Cg_max; (void)Cc_min; (void)Cc_max;
+    std::cerr << "run_nsga2_pagmo_bfe is disabled because pagmo library is not available." << std::endl;
+}
+#endif


### PR DESCRIPTION
## Summary
- add `run_nsga2_pagmo_bfe` that uses `pagmo` Batch Fitness Evaluator for parallel fitness evaluations
- declare the new function in `function.hpp`
- fix thread safety by using per-thread filenames during parallel evaluation

## Testing
- `make` *(fails: cannot find -lpagmo)*

------
https://chatgpt.com/codex/tasks/task_e_6849c71e30b48325b69a6475a80adf09