### PR TITLE
Add thread-safe NSGA-II helper functions

### DIFF
--- a/include/function.hpp
+++ b/include/function.hpp
@@ -36,12 +36,15 @@ void execute_julia(std::string jl_source);
 void read_jl(std::vector<ele_unit> &ele, std::vector<std::string> &jl_source);
 void write_jl(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source, std::size_t tid = 0);
 std::vector<std::vector<double>> read_csv(std::size_t tid = 0);
+void write_jl_mt(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source, std::size_t tid = 0);
+std::vector<std::vector<double>> read_csv_mt(std::size_t tid = 0);
 
 //display
 void display_element(const std::vector<ele_unit> &ele);
 
 //calculation
 result calculation(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source, std::size_t tid = 0);
+result calculation_mt(const std::vector<ele_unit> &ele, const std::vector<std::string> &jl_source, std::size_t tid = 0);
 double calc_gain(std::vector<std::vector<double>> csv_array, double freq_r);
 double calc_band(std::vector<std::vector<double>> csv_array, double gain);
 double calc_ripple(std::vector<std::vector<double>> csv_array, double freq_r);
@@ -58,6 +61,7 @@ double change_Lj(double Lj);
 void run_nsga2(int pop_size,int generations, std::vector<ele_unit> ele, std::vector<std::string> jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_par(int pop_size,int generations, std::vector<ele_unit> ele, std::vector<std::string> jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_pagmo(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
+void run_nsga2_pagmo_par(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_pagmo_codex(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_pagmo_bfe(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);
 void run_nsga2_pagmo_island(int pop_size, int generations, const std::vector<ele_unit>& ele, const std::vector<std::string>& jl_source, double Lj, double Cg_min, double Cg_max, double Cc_min, double Cc_max);

--- a/src/calculation/calculation_mt.cpp
+++ b/src/calculation/calculation_mt.cpp
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <cstdlib>
+#include <vector>
+#include <filesystem>
+#include <algorithm>
+#include <cmath>
+#include "function.hpp"
+
+
+using namespace std;
+
+
+result calculation_mt(const vector<ele_unit> &ele,
+                      const vector<string> &jl_source,
+                      std::size_t tid) {
+    // create per-thread script and CSV name using tid
+    stringstream jl_name, liness;
+    jl_name << "TWPA_thread";
+    if(tid != 0) jl_name << '_' << tid;
+    jl_name << ".jl";
+
+    write_jl_mt(ele, jl_source, tid);
+    result result;
+    display_element(ele);
+    cout << " exuecuting Julia ..." << endl;
+    execute_julia(jl_name.str()); // julia を実行
+
+    vector<vector<double>> csv_array = read_csv_mt(tid);
+
+    result.gain = calc_gain(csv_array, calc_freq_r(ele));
+    result.bandwidth = calc_band(csv_array, result.gain);
+    result.ripple = calc_ripple(csv_array, calc_freq_r(ele));
+
+    cout << " Gain     : " << result.gain << " dB" << endl;
+    cout << " Bandwidth: " << result.bandwidth<< " GHz" << endl;
+    cout << " Ripple   : " << result.ripple << " dB" << endl;
+    cout << " freq_r   : " << calc_freq_r(ele) << " GHz" << endl << endl;
+    cout << " impedance: " << calc_imp(ele) << " ohm" << endl << endl;
+
+
+    return result;
+}

--- a/src/file/read_csv_mt.cpp
+++ b/src/file/read_csv_mt.cpp
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <iostream>
+#include <fstream>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sstream>
+#include <thread>
+#include <math.h>
+#include <cmath>
+#include <cstdlib>
+#include <unistd.h>
+#include "function.hpp"
+#include <iomanip> 
+
+using namespace std;
+
+
+/* Josimの結果を配列に格納 */
+vector<vector<double>> read_csv_mt(std::size_t tid) {
+    double out;
+    stringstream outfile, delete_csv;
+    stringstream outline;
+    string line;
+    vector<vector<double>> csv_array;
+    outfile << "freq_gain_thread";
+    if(tid != 0) outfile << '_' << tid;
+    outfile << ".csv";
+    delete_csv << "rm -rf " << outfile.str();
+    /* テキストファイルの読み込み */
+    ifstream fp_csv(outfile.str());
+
+    if (!fp_csv.is_open()) {
+        cerr << "No output of JoSIM."  << endl;
+    }
+
+    fp_csv.seekg(0, ios::end);
+    if (fp_csv.tellg() == 0) {
+        cerr << "ERROR : Output File(.csv) is empty. Julia execution may have some errors." << endl;
+        fp_csv.close();
+        exit(1);
+    }
+    fp_csv.seekg(0, ios::beg);
+
+
+
+    // シーク位置を先頭の次の行に戻す(０行目がラベルであるため)
+    getline(fp_csv, line);
+
+    /* 配列に格納 */
+    while(getline(fp_csv, line)){            // 行を上から順に選択
+        stringstream outline(line);
+        vector<double> column;
+        while(outline >> out){
+            column.emplace_back(out);
+            if(outline.peek() == ','){
+                outline.ignore();
+            }
+        }
+        csv_array.emplace_back(column);
+    }
+    fp_csv.close();
+
+    system(delete_csv.str().c_str());
+
+    return csv_array;
+}

--- a/src/file/write_jl_mt.cpp
+++ b/src/file/write_jl_mt.cpp
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <iomanip> 
+#include <cstdio>
+#include <regex>
+#include <algorithm>
+#include <cmath>
+#include <mutex>
+#include "function.hpp"
+
+using namespace std;
+
+void write_jl_mt(const vector<ele_unit> &ele,
+                 const vector<string> &jl_source,
+                 std::size_t tid) {
+    stringstream jl_name, liness, csv_line;
+    jl_name << "TWPA_thread";
+    if(tid != 0) jl_name << '_' << tid;
+    jl_name << ".jl";
+    csv_line << "    open(\"freq_gain_thread";
+    if(tid != 0) csv_line << '_' << tid;
+    csv_line << ".csv\", \"w\") do io";
+    ofstream fpin(jl_name.str());
+    int y = 0;
+    vector<string> jl_source_copy = jl_source;
+    if(!fpin.is_open()){
+        cerr << "file not error in write_jl.cpp"  << endl;
+        return;
+    }        
+    for (int x = 0; x < ele.size(); x++) {
+        liness.clear();
+        liness.str("");
+        y = ele[x].line;
+        if(ele[x].name == "Lj"){
+            liness << "        " << ele[x].name << " => " << "IctoLj(" << ele[x].value  << ")" << ",";
+        }
+        else if(ele[x].name == "Ip"){
+            liness << "    " << ele[x].name << "  = " << ele[x].value;
+        }
+        else{
+            liness << "        " << ele[x].name << " => " << ele[x].value << ",";
+        }
+        jl_source_copy[y] = liness.str();
+    }
+    for (int x = 0; x < jl_source_copy.size(); x++) {     //内容を書き換えたjl_source_copy(バッファ)を全て書く
+        if(jl_source_copy[x].find("open") != string::npos){
+            jl_source_copy[x] = csv_line.str();
+        }
+        fpin << jl_source_copy[x] << endl;  
+    }
+    fpin.close();
+    
+    return;
+}

--- a/src/nsga2/nsga2_pagmo_par.cpp
+++ b/src/nsga2/nsga2_pagmo_par.cpp
@@ -1,0 +1,157 @@
+#include "function.hpp"
+#include <random>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <utility>
+#include <fstream>
+#include <atomic>
+
+#if __has_include(<pagmo/pagmo.hpp>)
+#include <pagmo/pagmo.hpp>
+#include <pagmo/algorithms/nsga2.hpp>
+#include <pagmo/population.hpp>
+#include <pagmo/types.hpp>
+#include <pagmo/batch_evaluators/thread_bfe.hpp>
+#define PAGMO_AVAILABLE 1
+#else
+#pragma message("pagmo library not found, run_nsga2_pagmo_par will be disabled")
+#define PAGMO_AVAILABLE 0
+#endif
+
+#if PAGMO_AVAILABLE
+using pagmo::vector_double;
+using pagmo::problem;
+using pagmo::algorithm;
+using pagmo::population;
+using pagmo::nsga2;
+
+//======================================
+// UDP: JosephsonCircuits を呼び出して (gain, bandwidth, ripple) を得る
+//======================================
+struct josephson_problem {
+    double Lj;
+    std::vector<ele_unit> ele;
+    std::vector<std::string> jl_source;
+    double Cg_min, Cg_max, Cc_min, Cc_max;
+
+    josephson_problem() = default;
+    josephson_problem(double Lj_, const std::vector<ele_unit>& ele_,
+                      const std::vector<std::string>& jl_src_)
+        : Lj(Lj_), ele(ele_), jl_source(jl_src_) {}
+
+    result eval(double Cg, double Cc) const {
+        auto tmp = ele;
+        change_param(tmp, "Cg", Cg);
+        change_param(tmp, "Cc", Cc);
+        double denom = 3.0 * change_Lj(Lj) / (49.0 * 49.0);
+        double Cn = denom - 2.0 * Cg - Cc;
+        if (Cn <= 0.0) {
+            return {0.0, 0.0, 1.0};
+        }
+        change_param(tmp, "Cn", Cn);
+        static std::atomic<std::size_t> eval_counter{0};
+        auto eval_id = eval_counter.fetch_add(1, std::memory_order_relaxed);
+        return calculation_mt(tmp, jl_source, eval_id);
+    }
+
+    vector_double fitness(const vector_double &x) const {
+        result r = eval(x[0], x[1]);
+        double f1 = -r.gain;
+        double f2 = -r.bandwidth;
+        if (r.ripple > 0.1) {
+            f1 = 1e6 + r.ripple;
+            f2 = 1e6 + r.ripple;
+        }
+        return {f1, f2};
+    }
+
+    std::pair<vector_double, vector_double> get_bounds() const {
+        return {{Cg_min, Cc_min}, {Cg_max, Cc_max}};
+    }
+
+    std::size_t get_nobj() const { return 2u; }
+    std::size_t get_nic() const { return 0u; }
+    std::size_t get_nec() const { return 0u; }
+
+    void set_bounds(double _Cg_min, double _Cg_max,
+                    double _Cc_min, double _Cc_max) {
+        Cg_min = _Cg_min;  Cg_max = _Cg_max;
+        Cc_min = _Cc_min;  Cc_max = _Cc_max;
+    }
+
+    std::string get_name() const { return "josephson_problem"; }
+};
+
+//======================================
+// run_nsga2_pagmo_par ：Pagmo を使った NSGA‐II 実行 (thread_bfe利用)
+//======================================
+void run_nsga2_pagmo_par(int pop_size,
+                     int generations,
+                     const std::vector<ele_unit>& ele,
+                     const std::vector<std::string>& jl_source,
+                     double Lj,
+                     double Cg_min, double Cg_max,
+                     double Cc_min, double Cc_max) {
+    josephson_problem prob_udp(Lj, ele, jl_source);
+    prob_udp.set_bounds(Cg_min, Cg_max, Cc_min, Cc_max);
+
+    pagmo::problem prob{prob_udp};
+
+    pagmo::algorithm algo{ pagmo::nsga2(
+        generations,
+        0.9,
+        20.0,
+        1.0/2.0,
+        20.0
+    ) };
+
+    pagmo::thread_bfe bfe{};
+
+    pagmo::population pop{prob, bfe, static_cast<unsigned int>(pop_size)};
+    pop = algo.evolve(pop);
+
+    std::ofstream ofs("nsga2_result.csv");
+    ofs << "Cg,Cc,Cn,gain,bandwidth,ripple\n";
+
+    std::cout << "# Cg\tCc\tCn\tgain\tbandwidth\tripple\n";
+    for (std::size_t i = 0; i < pop.size(); ++i) {
+        const auto xv = pop.get_x()[i];
+        double Cg = xv[0];
+        double Cc = xv[1];
+        result r = prob_udp.eval(Cg, Cc);
+        double denom = 3.0 * Lj / (49.0 * 49.0);
+        double Cn = denom - 2.0 * Cg - Cc;
+        if (r.ripple <= 0.1 && Cn > 0.0) {
+            std::cout << Cg << "\t"
+                      << Cc << "\t"
+                      << Cn << "\t"
+                      << r.gain << "\t"
+                      << r.bandwidth << "\t"
+                      << r.ripple << "\n";
+            ofs << Cg << ','
+                << Cc << ','
+                << Cn << ','
+                << r.gain << ','
+                << r.bandwidth << ','
+                << r.ripple << '\n';
+        }
+    }
+    ofs.close();
+}
+#else
+void run_nsga2_pagmo_par(int pop_size,
+                     int generations,
+                     const std::vector<ele_unit>& ele,
+                     const std::vector<std::string>& jl_source,
+                     double Lj,
+                     double Cg_min, double Cg_max,
+                     double Cc_min, double Cc_max) {
+    (void)pop_size; (void)generations; (void)ele; (void)jl_source;
+    (void)Lj; (void)Cg_min; (void)Cg_max; (void)Cc_min; (void)Cc_max;
+    std::cerr << "run_nsga2_pagmo_par is disabled because pagmo library is not available." << std::endl;
+}
+#endif
+


### PR DESCRIPTION
## Summary
- create thread-friendly versions of write_jl, read_csv and calculation
- update `run_nsga2_pagmo_par` to use `calculation_mt`
- expose new functions in the public header

## Testing
- `make` *(fails: cannot find -lpagmo)*

------
https://chatgpt.com/codex/tasks/task_e_6855ca30a6808325b37c52c813a554f5